### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Europe/Copenhagen"
+      time: "10:00"
+    commit-message:
+      prefix: "bot:"
+    reviewers:
+      - "Klintrup"
+    rebase-strategy: "auto"


### PR DESCRIPTION
This pull request introduces a new configuration for Dependabot in the `.github/dependabot.yml` file. The configuration is set to automatically update GitHub Actions on a weekly basis, with reviews assigned to "Klintrup". The commit messages for these updates will be prefixed with "bot:" and the rebase strategy is set to "auto".